### PR TITLE
Add dep for Buildkite agent.

### DIFF
--- a/buildkite_agent.rb
+++ b/buildkite_agent.rb
@@ -1,0 +1,23 @@
+dep "buildkite-agent" do
+  requires "buildkite-agent.managed"
+  requires "buildkite-agent.launchctl"
+end
+
+dep "buildkite-agent.managed", :buildkite_token do
+  requires "homebrew tap".with "buildkite/buildkite"
+
+  met? {
+    shell("brew list").include?("buildkite-agent")
+  }
+
+  meet {
+    shell("brew install --devel --token='#{buildkite_token}' buildkite-agent")
+  }
+
+  provides "buildkite-agent"
+end
+
+dep "buildkite-agent.launchctl", template: "launchctl" do
+  requires "buildkite-agent.managed"
+  service "buildkite-agent"
+end

--- a/buildkite_agent.rb
+++ b/buildkite_agent.rb
@@ -6,10 +6,6 @@ end
 dep "buildkite-agent.managed", :buildkite_token do
   requires "homebrew tap".with "buildkite/buildkite"
 
-  met? {
-    shell("brew list").include?("buildkite-agent")
-  }
-
   meet {
     shell("brew install --devel --token='#{buildkite_token}' buildkite-agent")
   }


### PR DESCRIPTION
This adds a dep for installing the Buildkite agent via homebrew and adding it to `brew services`.

Running `babushka "icelab:buildkite-agent"` will prompt users for their Buildkite account's agent token. The agent starts automatically, and can be controlled with `brew services [stop | start] buildkite-agent`.

Once we're happy with how it works we could add it to the workstation dep.